### PR TITLE
6 add cams dataset for influx forecast

### DIFF
--- a/atlite/__init__.py
+++ b/atlite/__init__.py
@@ -30,7 +30,8 @@ from atlite.gis import ExclusionContainer, compute_indicatormatrix, regrid
 from atlite.resource import cspinstallations, solarpanels, windturbines
 
 # e.g. "0.17.1" or "0.17.1.dev4+ga3890dc0" (if installed from git)
-__version__ = version("atlite")
+# __version__ = version("atlite")
+__version__ = "0.17.1.dev4+ga3890dc0"
 # e.g. "0.17.0" # TODO, in the network structure it should use the dev version
 match = re.match(r"(\d+\.\d+(\.\d+)?)", __version__)
 assert match, f"Could not determine release_version of pypsa: {__version__}"

--- a/atlite/datasets/ifs_ens.py
+++ b/atlite/datasets/ifs_ens.py
@@ -164,7 +164,7 @@ def get_data_influx(retrieval_params):
 
     ds = _rename_and_clean_coords(ds)
 
-    ds = ds.rename({"fdir": "influx_direct", "tisr": "influx_toa"})
+    ds = ds.rename({"cdir": "influx_direct", "tisr": "influx_toa"})
     ds["albedo"] = (
         ((ds["ssrd"] - ds["ssr"]) / ds["ssrd"].where(ds["ssrd"] != 0))
         .fillna(0.0)

--- a/atlite/datasets/ifs_ens.py
+++ b/atlite/datasets/ifs_ens.py
@@ -164,7 +164,7 @@ def get_data_influx(retrieval_params):
 
     ds = _rename_and_clean_coords(ds)
 
-    ds = ds.rename({"cdir": "influx_direct", "tisr": "influx_toa"})
+    ds = ds.rename({"fdir": "influx_direct", "tisr": "influx_toa"})
     ds["albedo"] = (
         ((ds["ssrd"] - ds["ssr"]) / ds["ssrd"].where(ds["ssrd"] != 0))
         .fillna(0.0)


### PR DESCRIPTION
This pull request updates how the `__version__` variable is set in the `atlite/__init__.py` file. Instead of dynamically determining the version using the `version("atlite")` function, it now assigns a hardcoded version string directly.

Versioning update:

* Changed the assignment of `__version__` to a fixed string `"0.17.1.dev4+ga3890dc0"` instead of using the `version("atlite")` function.